### PR TITLE
Document URL encoding requirement for mailto query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ func main() {
 
 `mailto:` [scheme](https://datatracker.ietf.org/doc/html/rfc6068) is supported. Only `subject` and `from` query params are used.
 
+**Note:** Query parameter values must be URL-encoded. In particular, email addresses containing `+` (e.g. `noreply+tag@example.com`) must use `%2B`, otherwise `+` is interpreted as a space. Use `url.QueryEscape` for all parameter values.
+
 Examples:
 
 - `mailto:"John Wayne"<john@example.org>?subject=test-subj&from="Notifier"<notify@example.org>`

--- a/email.go
+++ b/email.go
@@ -81,6 +81,10 @@ func NewEmail(smtpParams SMTPParams) *Email {
 // with "mailto:" schema.
 // "unsubscribeLink" passed as a header, https://support.google.com/mail/answer/81126 -> "Use one-click unsubscribe"
 //
+// Note: query parameter values in the mailto URL must be properly URL-encoded. In particular, email addresses
+// containing "+" (e.g. "noreply+tag@example.com") must use "%2B" instead, otherwise "+" is interpreted as a space
+// per standard URL query string parsing. Use url.QueryEscape for all parameter values.
+//
 // Example:
 //
 // - mailto:"John Wayne"<john@example.org>?subject=test-subj&from="Notifier"<notify@example.org>


### PR DESCRIPTION
## Summary
- Added note to Send godoc about URL-encoding query parameter values in mailto URLs
- Added note to README email section
- Specifically calls out the + character being interpreted as a space if not encoded as %2B

Relates to umputun/remark42#1946