### PR TITLE
Update dependencies to latest and bump to go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
         id: go
 
       - name: build and test

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/go-pkgz/notify
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-pkgz/email v0.6.0
-	github.com/go-pkgz/lgr v0.12.1
+	github.com/go-pkgz/lgr v0.12.3
 	github.com/go-pkgz/repeater/v2 v2.2.0
 	github.com/microcosm-cc/bluemonday v1.0.27
-	github.com/slack-go/slack v0.17.3
+	github.com/slack-go/slack v0.27.0
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/net v0.47.0
+	golang.org/x/net v0.56.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-pkgz/email v0.6.0 h1:snZnXldjeF4PgKSjnx9Fa25mtOgFpAOEeWvnQvrxjLE=
 github.com/go-pkgz/email v0.6.0/go.mod h1:+wgi4x7S33IuCzfcCM5euN0GwQG6XvO/PBLxrNffYLI=
-github.com/go-pkgz/lgr v0.12.1 h1:8GVfG2rSARq3Eaj5PP158rtBR2LHVGkwioIkQBGbvKg=
-github.com/go-pkgz/lgr v0.12.1/go.mod h1:A4AxjOthFVFK6jRnVYMeusno5SeDAxcLVHd0kI/lN/Y=
+github.com/go-pkgz/lgr v0.12.3 h1:QDug7kRkEsuQtruT9fNF5PVT2kZUqCDPc4GmsgS3fP8=
+github.com/go-pkgz/lgr v0.12.3/go.mod h1:lpCDgVvCIxBHZp8+sGCj9MPctIzKZyZ3QdE19ddqd54=
 github.com/go-pkgz/repeater/v2 v2.2.0 h1:8nZR/NaknmLfx2YMHbr78u9OL4Xj+8+romm9dz4FpMg=
 github.com/go-pkgz/repeater/v2 v2.2.0/go.mod h1:RgX5vUbLKq7PV82QUDP5pFbQS1os4Z+U9XzKymK23A8=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
@@ -18,12 +18,12 @@ github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwX
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
-github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
+github.com/slack-go/slack v0.27.0 h1:VWOpUzOK6UAPCCQlFxl79jhv8a/b+GOSJMnWziDJ8B8=
+github.com/slack-go/slack v0.27.0/go.mod h1:UEe+jmo9WLlwHB04qsOrTDvqM7Aa4rQL3O5wF3n0hx4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/net v0.47.0 h1:Mx+4dIFzqraBXUugkia1OOvlD6LemFo1ALMHjrXDOhY=
-golang.org/x/net v0.47.0/go.mod h1:/jNxtkgq5yWUGYkaZGqo27cfGZ1c5Nen03aYrrKpVRU=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -33,7 +33,7 @@ func TestTelegram_New(t *testing.T) {
 	require.EqualError(t, err, "can't retrieve bot info from Telegram API: received empty result")
 
 	st := time.Now()
-	_, err = NewTelegram(TelegramParams{
+	_, err = NewTelegram(TelegramParams{ //nolint:gosec // G101: test fixture token, not a real credential
 		Token:     "non-json-resp",
 		Timeout:   2 * time.Second,
 		apiPrefix: ts.URL + "/",
@@ -86,7 +86,7 @@ func TestTelegram_Send(t *testing.T) {
 	require.NoError(t, err)
 
 	tb = &Telegram{
-		TelegramParams: TelegramParams{
+		TelegramParams: TelegramParams{ //nolint:gosec // G101: test fixture token, not a real credential
 			Token:     "non-json-resp",
 			apiPrefix: ts.URL + "/",
 		}}


### PR DESCRIPTION
Updates all modules to their latest versions. The patched releases require go 1.25, so the `go` directive and CI `go-version` move to 1.25.

## Updates
- `slack-go/slack` 0.17.3 → 0.27.0 — fixes GHSA-gxhx-2686-5h9g (the Dependabot alert)
- `golang.org/x/net` 0.47.0 → 0.56.0 — fixes 7 advisories (GO-2026-5025/5027/5028/5029/5030 html XSS, GO-2026-5026 idna, GO-2026-4918 http2), reached via bluemonday
- `go-pkgz/lgr` 0.12.1 → 0.12.3

## Notes
- `golang.org/x/net` was the more relevant finding here: govulncheck flags it as reachable through bluemonday's HTML sanitiser, whereas the slack advisory is present but not called by this package. Both patched lines require go 1.25.0, which is what forces the toolchain bump.
- Two gosec G101 findings on test-fixture tokens in `telegram_test.go` are suppressed with explained `//nolint` directives.

Verified locally: `go test -race`, `go vet`, `golangci-lint run`, and `govulncheck ./...` all clean.

Supersedes #36.